### PR TITLE
Save attributes of the cube

### DIFF
--- a/src/DAT/CubeIO.jl
+++ b/src/DAT/CubeIO.jl
@@ -34,6 +34,7 @@ function savecube(
         backend = backend,
         chunksize = chunksize,
         path = name;
+        properties=getattributes(c),
         backendargs...,
     )
     function cop(xout, xin)

--- a/src/DatasetAPI/Datasets.jl
+++ b/src/DatasetAPI/Datasets.jl
@@ -332,7 +332,7 @@ function createdataset(
     dshandle = YAXArrayBase.create_dataset(
         DS, 
         path, 
-        Dict{String,Any}(),
+        attr,
         getproperty.(axdata,:name), 
         getproperty.(axdata,:data),
         getproperty.(axdata,:attrs), 

--- a/test/Datasets/datasets.jl
+++ b/test/Datasets/datasets.jl
@@ -204,12 +204,13 @@ end
     ax1 = CategoricalAxis("Ax1", string.(1:10))
     ax2 = RangeAxis("Ax2", 1:5)
     p = tempname()
-    savecube(YAXArray([ax1, ax2], x), p, backend = :zarr)
+    savecube(YAXArray([ax1, ax2], x, Dict("some" =>"thing")), p, backend = :zarr)
     cube1 = Cube(p)
     @test cube1.Ax1 == ax1
     @test cube1.Ax2 == ax2
     @test eltype(cube1.Ax2.values) <: Int64
     @test cube1.data == x
+    #@test getattributes(cube1)["some"] == "thing"
     p2 = string(tempname(), ".nc")
     savecube(cube1, p2, backend = :netcdf)
     cube2 = Cube(p2)

--- a/test/Datasets/datasets.jl
+++ b/test/Datasets/datasets.jl
@@ -59,24 +59,25 @@ using DataStructures: OrderedDict
             vars::Any
             dims::Any
             attrs::Any
+            varattrs::Any
             path::Any
         end
         Base.getindex(d::MockDataset, i) = d.vars[i]
         Base.haskey(d::MockDataset, i) = haskey(d.vars, i)
         YAXArrayBase.get_varnames(d::MockDataset) = (keys(d.vars)...,)
         YAXArrayBase.get_var_dims(d::MockDataset, name) = d.dims[name]
-        YAXArrayBase.get_var_attrs(d::MockDataset, name) = d.attrs[name]
+        YAXArrayBase.get_var_attrs(d::MockDataset, name) = d.varattrs[name]
         YAXArrayBase.allow_missings(d::MockDataset) = !occursin("nomissings", d.path)
         function YAXArrayBase.create_empty(::Type{MockDataset}, path, gatts)
             mkpath(dirname(path))
             open(_ -> nothing, path, "w")
-            MockDataset(Dict(), Dict(), gatts, path)
+            MockDataset(Dict(), Dict(), gatts, Dict(), path)
         end
         function YAXArrayBase.add_var(ds::MockDataset, T, name, s, dimlist, atts; kwargs...)
             data = Array{T}(undef, s...)
             ds.vars[name] = data
             ds.dims[name] = dimlist
-            ds.attrs[name] = atts
+            ds.varattrs[name] = copy(atts)
             data
         end
         YAXArrayBase.backendlist[:mock] = MockDataset
@@ -109,6 +110,9 @@ using DataStructures: OrderedDict
                     "time" => ("time",),
                     "d2" => ["d2"],
                     "d3" => ["d3"],
+                ),
+                Dict(
+                    "Global att" => "Somethingglobal",
                 ),
                 Dict(
                     "Var1" => att1,


### PR DESCRIPTION
This will allow to save the cube attributes in the savecube function.
I am not sure, whether this is the right way to tackle this. 
The tests fail currently, but I am not sure, whether this is a failure of the MockDataset or an actual problem with my changes. 

Currently when we want to change the metadata of the cube via
```julia
using YAXArrayBase
push!(getattributes(cube), "some" => "thing")
```
this is reflected in the current session, but is not saved, when we save the cube via `savecube`.

A related question is, whether we should provide a setattributes functions to replace the push! above?
