### PR TITLE
Allow abstract vector in subsetcube for RangeAxis

### DIFF
--- a/src/Cubes/Cubes.jl
+++ b/src/Cubes/Cubes.jl
@@ -229,7 +229,7 @@ interpretsubset(subexpr::NTuple{2,Int}, ax::RangeAxis{T}) where {T<:TimeType} =
 interpretsubset(subexpr::UnitRange{<:Integer}, ax::RangeAxis{T}) where {T<:TimeType} =
     interpretsubset(T(first(subexpr))..T(last(subexpr) + 1), ax)
 interpretsubset(subexpr::Interval, ax) = interpretsubset((subexpr.left, subexpr.right), ax)
-interpretsubset(subexpr::AbstractVector, ax::CategoricalAxis) =
+interpretsubset(subexpr::AbstractVector, ax) =
     axVal2Index.(Ref(ax), subexpr, fuzzy = true)
 
 

--- a/test/Cubes/cubes.jl
+++ b/test/Cubes/cubes.jl
@@ -115,6 +115,9 @@ using YAXArrays, YAXArrayBase, Test, Dates
         @test s2.data == [1 17 13; 2 18 14; 3 19 15]
         @test s2.axes[1] == RangeAxis("XVals", 1.0:3.0)
         @test s2.axes[2] == CategoricalAxis("YVals", [1, 5, 4])
+
+        svec = a[X=[1,2]]
+        @test svec.axes[1] == RangeAxis("XVals", 1.0:2.0)
     end
 
 end


### PR DESCRIPTION
This allows to use an abstract vector for subsetting of a RangeAxis. 
This is needed, so that I can make a temporal intersection of an irregular sampled Sentinel-1 cube with a daily sampled cube. 

```julia
julia> fluxdata[time=hainichorg.Time.values]
```
We could also allow the following syntax but I am not entirely sure, whether this is a good idea. 

```julia
julia> fluxdata[Time=hainichorg.Time]

julia> fluxdata[Time=hainichorg]
```
The last one assumes, that hainichorg has also an Axis with the  axname `Time`.
To achieve this we would need to add the following methods to `interpretsubset`

```julia
interpretsubset(subexpr::CubeAxis, ax) = axVal2Index.(Ref(ax), subexpr.values)
interpretsubset(subexpr::YAXArray, ax) = interpretsubset(getAxis(axname(ax), subexpr), ax)
```

