### PR TITLE
Allow fuzzy search on the whole descriptor

### DIFF
--- a/src/Cubes/Axes.jl
+++ b/src/Cubes/Axes.jl
@@ -159,12 +159,12 @@ function axVal2Index(axis::CategoricalAxis{String}, v::String; fuzzy::Bool = fal
     if r === nothing
         if fuzzy
             r = findall(axis.values) do i
-                startswith(lowercase(i), lowercase(v[1:min(length(i), length(v))]))
+                occursin(lowercase(v), lowercase(i))#, lowercase(v[1:min(length(i), length(v))]))
             end
             if length(r) == 1
                 return (r[1])
             else
-                error("Could not find unique value of $v in $axis")
+                error("Could not find unique value of $v in $axis found $(length(r)) occurences.")
             end
         else
             error("$v not found in $axis")

--- a/test/Cubes/axes.jl
+++ b/test/Cubes/axes.jl
@@ -65,4 +65,5 @@
     @test findAxis(RangeAxis("FloatRange", 1.0:-0.1:0.1), axlist) == 3
     @test getAxis(RangeAxis("FloatRange", 1.0:-0.1:0.1), axlist) ==
           RangeAxis("FloatRange", 1.0:-0.1:0.1)
+    @test axVal2Index(axlist[1], "wo", fuzzy=true) == 2
 end


### PR DESCRIPTION
So far, the fuzzy search checked only for the start of the value.
this would search the whole values for an occurence of desc.
