### PR TITLE
Fix mapcube ambiguity

### DIFF
--- a/src/DAT/DAT.jl
+++ b/src/DAT/DAT.jl
@@ -299,7 +299,7 @@ mapCube(fu::Function, cdata, addargs...; kwargs...) =
     mapCube(fu, (cdata,), addargs...; kwargs...)
 
 function mapCube(
-    f,
+    f::Function,
     in_ds::Dataset,
     addargs...;
     indims = InDims(),


### PR DESCRIPTION
This is a first step for testing the package with Aqua and fixing ambiguities in the function definitions. 

Before I can continue with that, we would need to set up a proper testset for the axval2index and subsetting functions, because there are most of the ambiguities. 