### PR TITLE
Check for step length of zero in axval2index

### DIFF
--- a/src/Cubes/Axes.jl
+++ b/src/Cubes/Axes.jl
@@ -200,6 +200,8 @@ abshalf(a::Month) = iseven(Dates.value(a)) ? a / 2 : Month(a ÷ 2) + Day(15)
 """
 function axVal2Index(a::RangeAxis{<:Any,<:Any,<:AbstractRange}, v; fuzzy=false)
     dt = v - first(a.values)
+    s = step(a.values)
+    s == 0 && return 1
     r = round(Int, dt / step(a.values)) + 1
     return max(1, min(length(a.values), r))
 end

--- a/test/Cubes/axes.jl
+++ b/test/Cubes/axes.jl
@@ -21,6 +21,8 @@
             DateTime(2002, 1, 1):Day(1):DateTime(2002, 1, 31),
             Hour(24),
         ),
+        (RangeAxis, "Single_IntRange", 1:1, 0),
+
         #This is currently not used, because we need to design, how this should behave.
         (
             RangeAxis,


### PR DESCRIPTION
This is necessary, because otherwise the subsetting with a single value fails for abstract ranges.
This is fixing the first part of issue #169 . 

