### PR TITLE
Rename ESDL to EarthDataLab in the Integration Test

### DIFF
--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -21,7 +21,7 @@ jobs:
         julia-version: [1]
         os: [ubuntu-latest]
         package:
-          - {user: esa-ESDL, repo: ESDL.jl}
+          - {user: JuliaDataCubes, repo: EarthDataLab.jl}
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This fixes the Integration Test to actually test EarthDataLab and not the old ESDL.jl repo.