### PR TITLE
Implement nicer printing for dataset

### DIFF
--- a/src/DatasetAPI/Datasets.jl
+++ b/src/DatasetAPI/Datasets.jl
@@ -89,11 +89,17 @@ function to_dataset(c;datasetaxis = "Variable", name = get(c.properties,"name","
 end
 
 function Base.show(io::IO, ds::Dataset)
+    sharedaxs = intersect([caxes(c) for (n,c) in ds.cubes]...)
     println(io, "YAXArray Dataset")
-    println(io, "Dimensions: ")
-    foreach(a -> println(io, "   ", a), values(ds.axes))
-    print(io, "Variables: ")
-    foreach(i -> print(io, i, " "), keys(ds.cubes))
+    println(io, "Shared Axes: ")
+    foreach(a -> println(io, "   ", a), sharedaxs)
+    println(io, "Variables: ")
+    for (k,c) in ds.cubes
+        println(io, k)
+        specaxes = setdiff(caxes(c), sharedaxs)
+        foreach(i-> println(io," └── ", i), specaxes)
+    end
+    #foreach(i -> print(io, i, " "), keys(ds.cubes))
     if !isempty(ds.properties)
         println(io)
         print(io,"Properties: ")

--- a/test/Datasets/datasets.jl
+++ b/test/Datasets/datasets.jl
@@ -21,13 +21,13 @@ using DataStructures: OrderedDict
         s = split(String(take!(b)), "\n")
         s2 = """
         YAXArray Dataset
-        Dimensions:
+        Shared Axes:
         XVals               Axis with 4 Elements from 1.0 to 4.0
         YVals               Axis with 5 elements: 1 2 3 4 5
-        Time                Axis with 12 Elements from 2001-01-15 to 2001-12-15
-        Variables: avar something smaller """
+        Variables: 
+        """
         s2 = split(s2, "\n")
-        #     @test s[[1,2,6]] == s2[[1,2,6]]
+             @test s[[1]] == s2[[1]]
         #     @test all(i->in(i,s2), s[3:5])
         for n in [:avar, :something, :smaller, :XVals, :Time, :YVals]
             @test n in propertynames(ds)


### PR DESCRIPTION
This prints the shared axes together and indicates the additional axes per cube. This should make it easier to understand datasets with multiple axes.
This should close #192 . I still need to implement tests for this. 
The dataset printing looks now like this:

```julia
julia> ds
YAXArray Dataset
Shared Axes: 
   XVals               Axis with 4 Elements from 1.0 to 4.0
   YVals               Axis with 5 elements: 1 2 3 4 5 
Variables: 
avar
 └── Time                Axis with 12 Elements from 2001-01-15 to 2001-12-15
 └── Some Category       Axis with 3 Elements from a to c
something
 └── Time                Axis with 12 Elements from 2001-01-15 to 2001-12-15
 └── Some Category       Axis with 3 Elements from a to c
smaller
```