### PR TITLE
Allow constructing cubes from different eltypes

### DIFF
--- a/src/DatasetAPI/Datasets.jl
+++ b/src/DatasetAPI/Datasets.jl
@@ -321,11 +321,18 @@ function Cube(ds::Dataset; joinname = "Variable")
     # TODO This is an ugly workaround to merge cubes with different element types,
     # There should bde a more generic solution
     eltypes = map(eltype, values(ds.cubes))
-    majtype = findmax(counter(eltypes))[2]
+    prom_type = first(eltypes)
+    for i in 2:length(eltypes)
+        prom_type = promote_type(prom_type,eltypes[i])
+        if !isconcretetype(prom_type)
+            wrongvar = collect(keys(ds.cubes))[i]
+            throw(ArgumentError("Could not promote element types of cubes in dataset to a common concrete type, because of Variable $wrongvar"))
+        end
+    end
     newkeys = Symbol[]
     for k in keys(ds.cubes)
         c = ds.cubes[k]
-        if all(axn -> findAxis(axn, c) !== nothing, dls) && eltype(c) == majtype
+        if all(axn -> findAxis(axn, c) !== nothing, dls)
             push!(newkeys, k)
         end
     end
@@ -333,7 +340,13 @@ function Cube(ds::Dataset; joinname = "Variable")
         return ds.cubes[first(newkeys)]
     else
         varax = CategoricalAxis(joinname, string.(newkeys))
-        cubestomerge = [ds.cubes[k] for k in newkeys]
+        cubestomerge = map(newkeys) do k
+            if eltype(ds.cubes[k]) <: prom_type
+                ds.cubes[k]
+            else
+                map(prom_type,ds.cubes[k])
+            end
+        end
         foreach(
         i -> haskey(i.properties, "name") && delete!(i.properties, "name"),
         cubestomerge,

--- a/test/Datasets/datasets.jl
+++ b/test/Datasets/datasets.jl
@@ -372,6 +372,7 @@ end
     a2 = YAXArray(rand(Float32,10,10))
     a3 = YAXArray(rand(Int16,10,10))
     a4 = YAXArray(rand(Float64,10,10))
+    a5 = YAXArray(fill("hello",10,10))
     ds = Dataset(a=a1, b=a2,c=a3,d=a4)
 
     c = Cube(ds)
@@ -380,4 +381,7 @@ end
     x = c[var="c"][:,:]
     @test eltype(x) <: Float64
     @test x == Float64.(a3.data)
+
+    ds = Dataset(a=a1, b=a2,c=a3,d=a4,e=a5)
+    @test_throws ArgumentError Cube(ds)
 end

--- a/test/Datasets/datasets.jl
+++ b/test/Datasets/datasets.jl
@@ -367,3 +367,17 @@ end
     @test mean_slice[:,:] == ones(20,5)
 end
 
+@testset "Making Cubes from heterogemous data types" begin
+    a1 = YAXArray(rand(Int8,10,10))
+    a2 = YAXArray(rand(Float32,10,10))
+    a3 = YAXArray(rand(Int16,10,10))
+    a4 = YAXArray(rand(Float64,10,10))
+    ds = Dataset(a=a1, b=a2,c=a3,d=a4)
+
+    c = Cube(ds)
+    @test size(c) == (10,10,4)
+    @test eltype(c) <: Float64
+    x = c[var="c"][:,:]
+    @test eltype(x) <: Float64
+    @test x == Float64.(a3.data)
+end


### PR DESCRIPTION
So far cubes in a dataset that had different element types than the majority of cubes were simply submitted when calling `Cube` on a dataset. This is fixed to some extent in this PR if all types can be promoted to a discrete common type. An error message is thrown if promotion fails. 