### PR TITLE
Add example for vector data cube

### DIFF
--- a/docs/examples/UserGuide/create_from_func.jl
+++ b/docs/examples/UserGuide/create_from_func.jl
@@ -55,4 +55,45 @@ gen_cube = mapCube(g, (lon, lat, time);
 # !!! info "slicing dim"
 #     Note that now the broadcasted dimension is `lon`.
 
-gen_cube.data[:,:,1]
+gen_cube.data[:, :, 1]
+
+# ## Generate Cube: Modify dimensions
+
+# One can also change the dimensions of a YAXArray.
+# For example, the location of `gen_cube` can be also expressed as a region or area of interest.
+# The following example transforms the raster data cube with two spatial dimensions,
+# i.e., longitude and latitude, into a [vector data cube](https://r-spatial.org/r/2022/09/12/vdc.html) with just one spatial dimension i.e. the region (e.g. district or country).
+
+# First, create a function `geo_region` to calculate the region for given geographical coordinates. In practice, one might use a spatial join of points to polygons here.
+
+function get_region(lon, lat)
+    1 <= lon < 10 && 1 <= lat < 5 && return "A"
+    1 <= lon < 10 && 5 <= lat < 10 && return "B"
+    10 <= lon < 15 && 1 <= lat < 5 && return "C"
+    return "D"
+end
+
+# Next, create a function `transform_cube` that will aggregate the values for any given time step.
+# `xin` is the raster data at one time step that is a Matrix with values `xin[lon, lat]`
+# `xout` is the vector data at one time step that is a Vector with values `xout[region]`
+
+function transform_cube(xout, xin, regions, points_to_regions_matrix)
+    result = Vector{eltype(xin)}(undef, length(xout))
+    for (i, region) in enumerate(regions)
+        region_points = findall(isequal(region), points_to_regions_matrix)
+        result[i] = sum(xin[region_points]) # Aggregate all points of this region
+    end
+    xout .= result
+end
+
+regions = ["A", "B", "C", "D"]
+points_to_regions_matrix = [get_region(t...) for t = Iterators.product(gen_cube.lon, gen_cube.lat)]
+
+vector_cube = mapCube(
+    transform_cube,
+    gen_cube,
+    regions,
+    points_to_regions_matrix,
+    indims=InDims("lon", "lat"),
+    outdims=OutDims(CategoricalAxis("region", regions))
+)


### PR DESCRIPTION
I found it a bit difficult to use `mapCube` in situations, where dimensions are both removed and created. Thus, I added an example on how to create a vector data cube that aggregates points of the same region. This example is different from the others mentioned in file `create_from_func.jl`, because the transformation is not calculated elementwise as it is one in `f(lo, la, t) = (lo + la + Dates.dayofyear(t))` but requires information from the other dimensions as well, i.e. we need the longitude and latitude to calculate the aggregated value.