### PR TITLE
Increase patch number to 0.4.7

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "YAXArrays"
 uuid = "c21b50f5-aa40-41ea-b809-c0f5e47bfa5c"
 authors = ["Fabian Gans <fgans@bgc-jena.mpg.de>"]
-version = "0.4.6"
+version = "0.4.7"
 
 [deps]
 CFTime = "179af706-886a-5703-950a-314cd64e0468"


### PR DESCRIPTION
Add a last version before the breaking switch to DimensionalData, so that one could pin to version 0.4