### PR TITLE
Fix printing of YAXArrays as DD subtype.

### DIFF
--- a/src/Cubes/Cubes.jl
+++ b/src/Cubes/Cubes.jl
@@ -474,14 +474,7 @@ cubesize(::YAXArray{T,0}) where {T} = sizeof(T)
 getCubeDes(::DD.Dimension) = "Cube axis"
 getCubeDes(::YAXArray) = "YAXArray"
 getCubeDes(::Type{T}) where {T} = string(T)
-Base.show(io::IO, c::YAXArray) = show_yax(io, c)
-Base.show(io::IO, mime::MIME{Symbol("text/plain")}, c::YAXArray) = show_yax(io,c)
-
-function show_yax(io::IO, c)
-    println(io, getCubeDes(c), " with the following dimensions")
-    for a in caxes(c)
-        println(io, a)
-    end
+function DD.show_after(io::IO,mime, c::YAXArray)
     foreach(getattributes(c)) do p
         if p[1] in ("labels", "name", "units")
             println(io, p[1], ": ", p[2])

--- a/src/DatasetAPI/Datasets.jl
+++ b/src/DatasetAPI/Datasets.jl
@@ -93,19 +93,34 @@ end
 function Base.show(io::IO, ds::Dataset)
     sharedaxs = intersect([caxes(c) for (n,c) in ds.cubes]...)
     println(io, "YAXArray Dataset")
+
     println(io, "Shared Axes: ")
-    foreach(a -> println(io, "   ", a), sharedaxs)
+    show(io, MIME("text/plain"), tuple(sharedaxs...))
+    println(io,"")
     println(io, "Variables: ")
     for (k,c) in ds.cubes
-        println(io, k)
         specaxes = setdiff(caxes(c), sharedaxs)
-        foreach(i-> println(io," └── ", i), specaxes)
+        if !isempty(specaxes)
+            println(io)
+            println(io, k)
+            specaxes = setdiff(caxes(c), sharedaxs)
+            DD.Dimensions.print_dims(io, MIME("text/plain"), tuple(specaxes...))
+        else
+            print(io,k)
+            print(io, ", ")
+        end
+            #for ax in specaxes
+        #    println(io," └── ")
+        #    DD.Dimensions.show_compact(io, MIME("text/plain"),ax)
+        #end
     end
     #foreach(i -> print(io, i, " "), keys(ds.cubes))
+    #show(io, ds.properties)
     if !isempty(ds.properties)
         println(io)
         print(io,"Properties: ")
-        foreach(i -> print(io, i[1], " => ", i[2], " "), ds.properties)
+        println(io, ds.properties)
+    #    foreach(i -> print(io, i[1], " => ", i[2], " "), ds.properties)
     end
 end
 function Base.propertynames(x::Dataset, private::Bool = false)


### PR DESCRIPTION
This will improve the printing of the YAXArrays. 
A YAXArray is now printed using the DimensionalData show machinery with a custom `show_after` method, so that we don't print the underlying array, because that might induce a huge latency when working with external data.
The printing looks now like that:

``` julia
julia> c
384×192×251288 YAXArray{Float32,3} with dimensions: 
  Dim{:lon} Sampled{Float64} 0.0:0.9375:359.0625 ForwardOrdered Regular Points,
  Dim{:lat} Sampled{Float64} Float64[-89.28422753251364, -88.35700351866494, …, 88.35700351866494, 89.28422753251364] ForwardOrdered Irregular Points,
  Ti Sampled{DateTime} DateTime[2015-01-01T03:00:00, …, 2101-01-01T00:00:00] ForwardOrdered Irregular Points
units: K
name: tas
Total size: 69.02 GB
```