### PR TITLE
Fix using multiple input for lombscargle example

### DIFF
--- a/src/DAT/DAT.jl
+++ b/src/DAT/DAT.jl
@@ -654,7 +654,7 @@ function updatear(f, r, cube, indscol, loopinds, cache)
     else
         if f == :read
             d = getdata(cube)[indsall...]
-            cache[:] = d
+            cache .= d
         else
             _writedata(getdata(cube), cache, indsall)
         end


### PR DESCRIPTION
This change was needed to enable the use of the time axis in the mapCube inner function.
I should add a test for that. 
