### PR TITLE
Add a YAXArray function for DD.Dimension to wrap them as a cube

### DIFF
--- a/docs/examples/UserGuide/create_from_func.jl
+++ b/docs/examples/UserGuide/create_from_func.jl
@@ -6,7 +6,7 @@ using Dates
 # !!! warning This is currently broken.
 # This is broken after the switch to DimensionalData
 
-#=
+
 f(lo, la, t) = (lo + la + Dates.dayofyear(t))
 
 # ## Wrap function for mapCube output
@@ -20,12 +20,12 @@ end
 
 # ## Create Cube's Axes
 
-# We do this via `RangeAxis` for every dimension
-lon = (Dim{:lon}(range(1, 15)))
-lat = (Dim{:lat}(range(1, 10)))
+# We wrap the dimensions of every axis into a YAXArray to use them in the mapCube function.
+lon = YAXArray(Dim{:lon}(range(1, 15)))
+lat = YAXArray(Dim{:lat}(range(1, 10)))
 # And a time axis
 tspan =  Date("2022-01-01"):Day(1):Date("2022-01-30")
-time = (Dim{:time}( tspan))
+time = YAXArray(Dim{:time}( tspan))
 
 
 # ## Generate Cube from function
@@ -60,4 +60,3 @@ gen_cube = mapCube(g, (lon, lat, time);
 #     Note that now the broadcasted dimension is `lon`.
 
 gen_cube.data[:, :, 1]
-=#

--- a/src/Cubes/Cubes.jl
+++ b/src/Cubes/Cubes.jl
@@ -143,6 +143,9 @@ function YAXArray(x::AbstractArray)
     YAXArray(ax, x, props,chunks=chunks)
 end
 
+
+# Overload the YAXArray constructor for dimensional data to use them inside of mapCube
+YAXArray(dim::DD.Dimension) = YAXArray((dim,), dim.val)
 # Base utility overloads
 Base.size(a::YAXArray) = size(getdata(a))
 Base.size(a::YAXArray, i::Int) = size(getdata(a), i)

--- a/src/DAT/DAT.jl
+++ b/src/DAT/DAT.jl
@@ -179,7 +179,7 @@ end
 
 function interpretoutchunksizes(desc, axesSmall, incubes)
     if desc.chunksize == :max
-        map(ax -> axname(ax) => RegularChunks(length(ax),0,length(ax)), axesSmall)
+        map(ax -> string(DD.name(ax)) => RegularChunks(length(ax),0,length(ax)), axesSmall)
     elseif desc.chunksize == :input
         map(axesSmall) do ax
             for cc in incubes


### PR DESCRIPTION
This enables to use the dimensions as a cube in mapCube calls. Also reenables the documentation on filling a cube with a function.

We should be discussing in the future, whether we would like to reenable the direct use of a axis in the mapCube calls, because this was broken by the switch to DimensionalData. 
