### PR TITLE
Update DAT.jl

### DIFF
--- a/src/DAT/DAT.jl
+++ b/src/DAT/DAT.jl
@@ -714,7 +714,7 @@ struct AllLoopAxes{S,V} <: AxValCreator
     loopsyms::S
     loopaxvals::V
 end
-AllLoopAxes(a) = AllLoopAxes(map(DD.dim2key, a), map(i -> i.values, a))
+AllLoopAxes(a) = AllLoopAxes(map(DD.dim2key, a), map(i -> i.val, a))
 getlaxvals(::NoLoopAxes, cI, offscur) = ()
 getlaxvals(a::AllLoopAxes, cI, offscur) = (
     NamedTuple{a.loopsyms}(


### PR DESCRIPTION
Typo fixed. In DimensionalData ```i.values``` doesn't exist. It must be ```i.val```, otherwise the error ```type Dim has no field values``` pop-up