### PR TITLE
max_cache human writing

### DIFF
--- a/src/DAT/DAT.jl
+++ b/src/DAT/DAT.jl
@@ -401,7 +401,7 @@ Map a given function `fun` over slices of the data cube `cube`.
     Use InDims to discribe the input dimensions and OutDims to describe the output dimensions of the function.
 ### Keyword arguments
 
-* `max_cache=YAXDefaults.max_cache` String. e.g. ```max_cache="10MB" or ```max_cache=1GB``` maximum size of blocks that are read into memory, defaults to approx 10Mb.
+* `max_cache=YAXDefaults.max_cache` Float64 maximum size of blocks that are read into memory in bits e.g. ```max_cache=5.0e8```. Or String. e.g. ```max_cache="10MB" or ```max_cache=1GB``` defaults to approx 10Mb.
 * `indims::InDims` List of input cube descriptors of type [`InDims`](@ref) for each input data cube.
 * `outdims::OutDims` List of output cube descriptors of type [`OutDims`](@ref) for each output cube.
 * `inplace` does the function write to an output array inplace or return a single value> defaults to `true`
@@ -434,7 +434,7 @@ function mapCube(
     do_gc = true,
     kwargs...,
 )
-    if max_cache != YAXArrays.YAXDefaults.max_cache[]
+    if typeof(max_cache) == String
         if last(max_cache, 2) == "MB"
         max_cache = parse(Float64, max_cache[begin:end-2]) / (10^-6)
 

--- a/test/DAT/mapcube.jl
+++ b/test/DAT/mapcube.jl
@@ -28,4 +28,36 @@
         @test r.data[] == sum(yax.data)
 
     end
+
+    @testset "max cache inputs" begin
+
+        # Float64 
+        r = mapCube((a1, a2), indims=(indims, indims), outdims=outdims, max_cache = 6.0e8) do xout, x1, x2
+            xout .= x1 .+ x2
+        end
+        @test r.data == a1.data .+ permutedims(a2.data,(1,3,2))
+
+        # MB
+
+        r = mapCube((a1, a2), indims=(indims, indims), outdims=outdims, max_cache = "0.5MB") do xout, x1, x2
+            xout .= x1 .+ x2
+        end
+        @test r.data == a1.data .+ permutedims(a2.data,(1,3,2))
+
+        r = mapCube((a1, a2), indims=(indims, indims), outdims=outdims, max_cache = "3MB") do xout, x1, x2
+            xout .= x1 .+ x2
+        end
+        @test r.data == a1.data .+ permutedims(a2.data,(1,3,2))
+
+        r = mapCube((a1, a2), indims=(indims, indims), outdims=outdims, max_cache = "10MB") do xout, x1, x2
+            xout .= x1 .+ x2
+        end
+        @test r.data == a1.data .+ permutedims(a2.data,(1,3,2))
+
+        # GB
+        r = mapCube((a1, a2), indims=(indims, indims), outdims=outdims, max_cache = "0.1GB") do xout, x1, x2
+            xout .= x1 .+ x2
+        end
+        @test r.data == a1.data .+ permutedims(a2.data,(1,3,2))
+    end
 end

--- a/test/DAT/mapcube.jl
+++ b/test/DAT/mapcube.jl
@@ -31,33 +31,33 @@
 
     @testset "max cache inputs" begin
 
-        # Float64 
-        r = mapCube((a1, a2), indims=(indims, indims), outdims=outdims, max_cache = 6.0e8) do xout, x1, x2
+        x,y,z = X(1:4), Y(1:5), Z(1:6)
+        a1 = YAXArray((x,y,z), rand(4,5,6))
+        a2 = YAXArray((x,z,y), rand(4,6,5))
+        a3 = YAXArray((x,y), rand(4,5))
+        indims = InDims("x")
+        outdims = OutDims("x")
+
+        function simple_fun(xout, x1,x2)
             xout .= x1 .+ x2
         end
+
+        # Float64 
+        r = mapCube(simple_fun, (a1, a2), indims=(indims, indims), outdims=outdims, max_cache = 6.0e8)
         @test r.data == a1.data .+ permutedims(a2.data,(1,3,2))
 
         # MB
-
-        r = mapCube((a1, a2), indims=(indims, indims), outdims=outdims, max_cache = "0.5MB") do xout, x1, x2
-            xout .= x1 .+ x2
-        end
+        r = mapCube(simple_fun, (a1, a2), indims=(indims, indims), outdims=outdims, max_cache = "0.5MB")
         @test r.data == a1.data .+ permutedims(a2.data,(1,3,2))
 
-        r = mapCube((a1, a2), indims=(indims, indims), outdims=outdims, max_cache = "3MB") do xout, x1, x2
-            xout .= x1 .+ x2
-        end
+        r = mapCube(simple_fun, (a1, a2), indims=(indims, indims), outdims=outdims, max_cache = "3MB")
         @test r.data == a1.data .+ permutedims(a2.data,(1,3,2))
 
-        r = mapCube((a1, a2), indims=(indims, indims), outdims=outdims, max_cache = "10MB") do xout, x1, x2
-            xout .= x1 .+ x2
-        end
+        r = mapCube(simple_fun, (a1, a2), indims=(indims, indims), outdims=outdims, max_cache = "10MB")
         @test r.data == a1.data .+ permutedims(a2.data,(1,3,2))
 
         # GB
-        r = mapCube((a1, a2), indims=(indims, indims), outdims=outdims, max_cache = "0.1GB") do xout, x1, x2
-            xout .= x1 .+ x2
-        end
+        r = mapCube(simple_fun, (a1, a2), indims=(indims, indims), outdims=outdims, max_cache = "0.1GB")
         @test r.data == a1.data .+ permutedims(a2.data,(1,3,2))
     end
 end


### PR DESCRIPTION
```max_cache``` in bits is fine, but not very human friendly. This is a downstream implementation of the YAXArraysToolbox package to get ```max_cache``` as e.g. ```max_cache="100MB"``` that can be useful for users of the YAXArrays package.