### PR TITLE
Revert "Make Metadata a type parameter of YAXArray"

### DIFF
--- a/src/Cubes/Cubes.jl
+++ b/src/Cubes/Cubes.jl
@@ -91,13 +91,13 @@ It can wrap normal arrays or, more typically DiskArrays.
 
 $(FIELDS)
 """
-struct YAXArray{T,N,A<:AbstractArray{T,N}, D, Me} <: AbstractDimArray{T,N,D,A} 
+struct YAXArray{T,N,A<:AbstractArray{T,N}, D} <: AbstractDimArray{T,N,D,A} 
     "`Tuple` of Dimensions containing the Axes of the Cube"
     axes::D
     "length(axes)-dimensional array which holds the data, this can be a lazy DiskArray"
     data::A
     "Metadata properties describing the content of the data"
-    properties::Me
+    properties::Dict{String}
     "Representation of the chunking of the data"
     chunks::GridChunks{N}
     "Cleaner objects to track which objects to tidy up when the YAXArray goes out of scope"
@@ -120,7 +120,7 @@ struct YAXArray{T,N,A<:AbstractArray{T,N}, D, Me} <: AbstractDimArray{T,N,D,A}
             throw(ArgumentError("Can not construct YAXArray, supplied chunk dimension is $(ndims(chunks)) while the number of dims is $(length(axes))"))
         else
             axes = DD.format(axes, data)
-            return new{eltype(data),ndims(data),typeof(data),typeof(axes), typeof(properties)}(
+            return new{eltype(data),ndims(data),typeof(data),typeof(axes)}(
                 axes,
                 data,
                 properties,

--- a/test/dimarray.jl
+++ b/test/dimarray.jl
@@ -82,14 +82,14 @@ end
     @test r.data == a2.data .+ reshape(a3.data,(4,1,5))
 
 
-#    x = Dim{:axis1}(1:10)
-#    yax = DimArray(rand(10), x)
-#    r = mapslices(sum, yax, dims=:axis1)
-#    @test r.data[] == sum(yax.data)
+    x = Dim{:axis1}(1:10)
+    yax = DimArray(rand(10), x)
+    r = mapslices(sum, yax, dims=:axis1)
+    @test r.data[] == sum(yax.data)
 
     #I am not sure, whether this is an actual use case 
     # and whether we would like to support the mix of symbol and string axisnames.
-#    @test_broken mapslices(sum, yax, dims="axis1")
+    @test_broken mapslices(sum, yax, dims="axis1")
 end
 
 @testitem "Moving Window DimArray" begin


### PR DESCRIPTION
Reverts JuliaDataCubes/YAXArrays.jl#370

Not only breaks yax inference but also DD ones.