### PR TITLE
Bump DimensionalData dependency to 0.27

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -42,7 +42,7 @@ jobs:
         env:
           JULIA_NUM_THREADS: '4'
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v4
         with:
           file: lcov.info
       - uses: coverallsapp/github-action@master

--- a/.github/workflows/Documenter.yml
+++ b/.github/workflows/Documenter.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Install documentation dependencies # for GLMakie plots
         run: sudo apt-get update && sudo apt-get install -y xorg-dev mesa-utils xvfb libgl1 freeglut3-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libxext-dev
       - name: Install documentation dependencies
-        run: DISPLAY=:0 xvfb-run -s '-screen 0 1024x768x24' julia --project=docs -e 'using Pkg; pkg"dev ."; Pkg.instantiate(); Pkg.precompile(); Pkg.status()'
+        run: DISPLAY=:0 xvfb-run -s '-screen 0 1024x768x24' julia --project=docs -e 'using Pkg; Pkg.Registry.update(); pkg"dev ."; Pkg.instantiate(); Pkg.precompile(); Pkg.status()'
       #- name: Creating new mds from src
       - name: Build and deploy docs
         env:

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "YAXArrays"
 uuid = "c21b50f5-aa40-41ea-b809-c0f5e47bfa5c"
 authors = ["Fabian Gans <fgans@bgc-jena.mpg.de>"]
-version = "0.5.5"
+version = "0.5.6"
 
 [deps]
 CFTime = "179af706-886a-5703-950a-314cd64e0468"
@@ -34,7 +34,7 @@ YAXArrayBase = "90b8fcef-0c2d-428d-9c56-5f86629e9d14"
 [compat]
 CFTime = "0.0, 0.1"
 DataStructures = "0.17, 0.18"
-DimensionalData = "0.26"
+DimensionalData = "0.27"
 DiskArrayTools = "0.1"
 DiskArrays = "0.3,0.4"
 DocStringExtensions = "0.8, 0.9"

--- a/src/Cubes/Cubes.jl
+++ b/src/Cubes/Cubes.jl
@@ -163,9 +163,9 @@ end
 # because getproperty is overloaded, propertynames should be as well
 function Base.propertynames(a::YAXArray, private::Bool=false)
     if private
-        (DD.dim2key.(DD.dims(a))..., :axes, :data, :properties)
+        (DD.name.(DD.dims(a))..., :axes, :data, :properties)
     else
-        (DD.dim2key.(DD.dims(a))..., :axes, :data)
+        (DD.name.(DD.dims(a))..., :axes, :data)
     end
 end
 
@@ -340,9 +340,9 @@ function outaxis_from_column(tab,icol)
     axname = schema(tab).names[icol]
     if eltype(axdata) <: AbstractString ||
         (!issorted(axdata) && !issorted(axdata, rev = true))
-        DD.rebuild(DD.key2dim(Symbol(axname)), axdata)
+        DD.rebuild(DD.name2dim(Symbol(axname)), axdata)
     else
-        DD.rebuild(DD.key2dim(Symbol(axname)), axdata)
+        DD.rebuild(DD.name2dim(Symbol(axname)), axdata)
     end
 end
 
@@ -356,13 +356,13 @@ function outaxis_from_data(cax,axinds,indlist)
             ax.values[i[ai-minai+1]]
         end
     end
-    DD.rebuild(DD.key2dim(Symbol(newname)), mergevals)
+    DD.rebuild(DD.name2dim(Symbol(newname)), mergevals)
 end
 chunkoffset(c) = grid_offset(eachchunk(c))
 
 # Implementation for YAXArrayBase interface
 YAXArrayBase.dimvals(x::YAXArray, i) = caxes(x)[i].val
-YAXArrayBase.dimname(x::YAXArray, i) = DD.dim2key(DD.dims(x)[i])
+YAXArrayBase.dimname(x::YAXArray, i) = DD.name(DD.dims(x)[i])
 YAXArrayBase.getattributes(x::YAXArray) = x.properties
 YAXArrayBase.iscontdim(x::YAXArray, i) = isa(caxes(x)[i], RangeAxis)
 YAXArrayBase.getdata(x::YAXArray) = getfield(x, :data)

--- a/src/Cubes/Slices.jl
+++ b/src/Cubes/Slices.jl
@@ -23,7 +23,7 @@ end
 dimvals(x::YAXSlice, i) = x.c.axes[x.otheraxes[1][i]].values
 
 function dimname(x::YAXSlice, i)
-    DD.dim2key(x.otheraxes[2][i])
+    DD.name(x.otheraxes[2][i])
 end
 
 getattributes(x::YAXSlice) = x.c.properties

--- a/src/DAT/DAT.jl
+++ b/src/DAT/DAT.jl
@@ -170,7 +170,7 @@ function getworkarray(c::InOutCube, ntr)
                 i1 = findfirst(isequal(i), c.icolon)
                 i1 === nothing || return caxes(c.cube)[c.icolon[i1]]
                 i2 = findfirst(isequal(i), c.iwindow)
-                DD.rebuild(DD.key2dim(DD.dim2key(caxes(c.cube)[c.iwindow[i2]])),UnitRange(-c.window[i2][1], c.window[i2][2]))
+                DD.rebuild(DD.key2dim(DD.name(caxes(c.cube)[c.iwindow[i2]])),UnitRange(-c.window[i2][1], c.window[i2][2]))
             end
             wrapWorkArray(c.desc.artype, w, axes)
         end
@@ -735,7 +735,7 @@ struct AllLoopAxes{S,V} <: AxValCreator
     loopsyms::S
     loopaxvals::V
 end
-AllLoopAxes(a) = AllLoopAxes(map(DD.dim2key, a), map(i -> i.val, a))
+AllLoopAxes(a) = AllLoopAxes(map(DD.name, a), map(i -> i.val, a))
 getlaxvals(::NoLoopAxes, cI, offscur) = ()
 getlaxvals(a::AllLoopAxes, cI, offscur) = (
     NamedTuple{a.loopsyms}(

--- a/src/DAT/dciterators.jl
+++ b/src/DAT/dciterators.jl
@@ -195,7 +195,7 @@ function CubeIterator(
         eltype(ic.cube)
     end
     et = (et..., map(i->eltype(i.val), loopaxes)...)
-    axnames = DD.dim2key.(loopaxes)
+    axnames = DD.name.(loopaxes)
     colnames = (map(Symbol, varnames)..., axnames...)
     CubeIterator(
         dc,

--- a/src/DAT/registration.jl
+++ b/src/DAT/registration.jl
@@ -27,7 +27,7 @@ findAxis(m::MovingWindow, c) = findAxis(m.desc, c)
 
 wrapWorkArray(::Type{Array}, a, axes) = a
 wrapWorkArray(T, a, axes) =
-    yaxcreate(T, a, map(DD.dim2key, axes), map(i -> i.values, axes), Dict{String, Any}())
+    yaxcreate(T, a, map(DD.name, axes), map(i -> i.values, axes), Dict{String, Any}())
 
 abstract type ProcFilter end
 struct AllMissing <: ProcFilter end

--- a/src/DAT/tablestats.jl
+++ b/src/DAT/tablestats.jl
@@ -139,11 +139,11 @@ function tooutaxis(
         if haskey(bycube.properties, "labels")
             idict = bycube.properties["labels"]
             axname = get(bycube.properties, "name", "Label")
-            outAxis = DD.rebuild(DD.key2dim(Symbol(axname)), collect(String, values(idict)))
+            outAxis = DD.rebuild(DD.name2dim(Symbol(axname)), collect(String, values(idict)))
             convertdict = Dict(k => i for (i, k) in enumerate(keys(idict)))
         else
             sort!(k)
-            outAxis = DD.rebuild(DD.key2dim(Symbol(s)), k)
+            outAxis = DD.rebuild(DD.name2dim(Symbol(s)), k)
             convertdict = Dict(k => i for (i, k) in enumerate(k))
         end
     else
@@ -155,7 +155,7 @@ function tooutaxis(
 end
 function tooutaxis(f, iter::CubeIterator, k, ibc)
     sort!(k)
-    outAxis = DD.rebuild(DD.key2dim(Symbol("Category$(ibc)")), k)
+    outAxis = DD.rebuild(DD.name2dim(Symbol("Category$(ibc)")), k)
     convertdict = Dict(k => i for (i, k) in enumerate(k))
     outAxis, convertdict
 end
@@ -173,7 +173,7 @@ getStatType(t::Type{<:Dict{<:Any,T}}) where {T} = T
 getStatOutAxes(tab, agg) = getStatOutAxes(tab, agg, getStatType(agg))
 getStatOutAxes(tab, agg, ::Type{<:OnlineStat}) = ()
 function getStatOutAxes(tab, agg, ::Type{<:Extrema})
-    (DD.rebuild(DD.key2dim(:Extrema), ["min", "max"]),)
+    (DD.rebuild(DD.name2dim(:Extrema), ["min", "max"]),)
 end
 function getStatOutAxes(tab, agg, ::Type{<:WeightedCovMatrix})
     varn = tab.schema.names
@@ -189,8 +189,8 @@ function getStatOutAxes(tab, agg, ::Type{<:WeightedCovMatrix})
 end
 function getStatOutAxes(tab,agg,::Type{<:Union{Ash,HistogramStat, WeightedAdaptiveHist}})
     nbin = getnbins(agg)
-    a1 = DD.rebuild(DD.key2dim(Symbol("Bin")), 1:nbin)
-    a2 = DD.rebuild(DD.key2dim(Symbol("Hist")), ["MidPoints", "Frequency"])
+    a1 = DD.rebuild(DD.name2dim(Symbol("Bin")), 1:nbin)
+    a2 = DD.rebuild(DD.name2dim(Symbol("Hist")), ["MidPoints", "Frequency"])
     (a1, a2)
 end
 function getByAxes(iter, agg::GroupedOnlineAggregator)

--- a/src/DatasetAPI/Datasets.jl
+++ b/src/DatasetAPI/Datasets.jl
@@ -43,13 +43,13 @@ function Dataset(; properties = Dict{String,Any}(), cubes...)
 end
 
 """
-to_dataset(c;datasetaxis = "Variable", name = "layer")  
+to_dataset(c;datasetaxis = "Variable", layername = "layer")  
 
 Convert a Data Cube into a Dataset. It is possible to treat one of 
 the Cube's axes as a "DatasetAxis" i.e. the cube will be split into 
 different parts that become variables in the Dataset. If no such 
 axis is specified or found, there will only be a single variable 
-in the dataset with the name `name`
+in the dataset with the name `layername`
 """
 function to_dataset(c;datasetaxis = "Variable", layername = get(c.properties,"name","layer"))
     axlist = DD.dims(c)

--- a/src/DatasetAPI/Datasets.jl
+++ b/src/DatasetAPI/Datasets.jl
@@ -219,7 +219,7 @@ end
 function toaxis(dimname, g, offs, len)
     axname = Symbol(dimname)
     if !haskey(g, dimname)
-        return DD.rebuild(DD.key2dim(axname), 1:len)
+        return DD.rebuild(DD.name2dim(axname), 1:len)
     end
     ar = get_var_handle(g, dimname)
     aratts = get_var_attrs(g, dimname)
@@ -232,15 +232,15 @@ function toaxis(dimname, g, offs, len)
         DD.Ti(tsteps[offs+1:end])
     elseif haskey(aratts, "_ARRAYVALUES")
         vals = identity.(aratts["_ARRAYVALUES"])
-        DD.rebuild(DD.key2dim(axname),(vals))
+        DD.rebuild(DD.name2dim(axname),(vals))
     else
         axdata = cleanaxiselement.(ar[offs+1:end])
         axdata = testrange(axdata)
         if eltype(axdata) <: AbstractString ||
             (!issorted(axdata) && !issorted(axdata, rev = true))
-            DD.rebuild(DD.key2dim(axname), axdata)
+            DD.rebuild(DD.name2dim(axname), axdata)
         else
-            DD.rebuild(DD.key2dim(axname), axdata)
+            DD.rebuild(DD.name2dim(axname), axdata)
         end
     end
 end
@@ -367,7 +367,7 @@ function Cube(ds::Dataset; joinname = "Variable", target_type = nothing)
     if length(newkeys) == 1
         return ds.cubes[first(newkeys)]
     else
-        varax = DD.rebuild(DD.key2dim(Symbol(joinname)), string.(newkeys))
+        varax = DD.rebuild(DD.name2dim(Symbol(joinname)), string.(newkeys))
         cubestomerge = map(newkeys) do k
             if eltype(ds.cubes[k]) <: prom_type
                 ds.cubes[k]

--- a/src/helpers.jl
+++ b/src/helpers.jl
@@ -1,5 +1,5 @@
 using DimensionalData: DimensionalData as DD
-const VecOrTuple{S} = Union{Vector{<:S},Tuple{Vararg{<:S}}} where {S}
+const VecOrTuple{S} = Union{Vector{<:S},Tuple{Vararg{S}}} where {S}
 
 abstract type AxisDescriptor end
 

--- a/test/Datasets/datasets.jl
+++ b/test/Datasets/datasets.jl
@@ -219,7 +219,7 @@ end
             ar = Cube(ds)
             @test ar isa YAXArray
             @test size(ar) == (10, 5, 2, 2)
-            @test DD.name.(ar.axes) == (:Time, :d2, :d3, :Variable)
+            @test DD.name.(ar.axes) == (:Ti, :d2, :d3, :Variable)
             @test DD.lookup(ar.axes[4]) == ["Var1", "Var3"]
         end
         @testset "Dataset creation" begin
@@ -230,7 +230,7 @@ end
             )
             # Basic
             newds, newds2 = YAXArrays.Datasets.createdataset(MockDataset, al)
-            @test DD.dim2key.(newds2.axes) == (:Time, :Xvals, :Variable)
+            @test DD.name.(newds2.axes) == (:Time, :Xvals, :Variable)
             @test DD.lookup(newds2.axes[1]) == Date(2001):Month(1):Date(2001, 12, 31)
             @test DD.lookup(newds2.axes[3]) == ["A", "B"]
             @test DD.lookup(newds2.axes[2]) == 1:10


### PR DESCRIPTION
This replaces the deprecated DimensionalData functions key2dim and dim2key with their new versions. 

The fix seemed to be very smooth but I am not sure whether this is breaking, because it might change the behaviour of the Ti and time axes. 