### PR TITLE
Use Ti also for dataset axis names

### DIFF
--- a/src/DAT/DAT.jl
+++ b/src/DAT/DAT.jl
@@ -727,7 +727,6 @@ function runLoop(dc::DATConfig, showprog)
             if dc.ntr[1] > 1
                 innerLoop_threaded(r, args...)
             else
-                @show "Running nonthreaded"
                 innerLoop(r,args...)
             end
             writeoutars(dc, r, outcaches)

--- a/src/DatasetAPI/Datasets.jl
+++ b/src/DatasetAPI/Datasets.jl
@@ -321,7 +321,7 @@ function open_dataset(g; driver = :all)
     end
     gatts = YAXArrayBase.get_global_attrs(g)
     gatts = Dict{String,Any}(string(k)=>v for (k,v) in gatts)
-    sdimlist = Dict(Symbol(k) => v.ax for (k, v) in dimlist)
+    sdimlist = Dict(DD.name(v.ax) => v.ax for (k, v) in dimlist)
     Dataset(allcubes, sdimlist,gatts)
 end
 #Base.getindex(x::Dataset; kwargs...) = subsetcube(x; kwargs...)

--- a/test/Datasets/datasets.jl
+++ b/test/Datasets/datasets.jl
@@ -215,7 +215,7 @@ end
             ds = open_dataset("test.mock")
             @test size(ds.Var1) == (10, 5, 2)
             @test size(ds.Var2) == (10, 5)
-            @test all(in(keys(ds.axes)), (:time, :d2, :d3))
+            @test all(in(keys(ds.axes)), (:Ti, :d2, :d3))
             ar = Cube(ds)
             @test ar isa YAXArray
             @test size(ar) == (10, 5, 2, 2)


### PR DESCRIPTION
`open_mfdataset` was broken in many cases because in the internal representation of a Datasets dimensions there was still `:time` keys mixed with `:Ti` axes. This makes the dataset consistently use `:Ti` so that axis merging works again. 