### PR TITLE
Fix show_after error when sizeof fails to determine DataType size

### DIFF
--- a/src/Cubes/Cubes.jl
+++ b/src/Cubes/Cubes.jl
@@ -508,12 +508,10 @@ getCubeDes(::Type{T}) where {T} = string(T)
 
 function DD.show_after(io::IO, mime, c::YAXArray)
     blockwidth = get(io, :blockwidth, 0)
-    DD.print_block_separator(io, "file size", blockwidth, blockwidth)
-    println(io, " ")
-    try
-        println(io, "  file size: ", formatbytes(cubesize(c)))
-    catch e
-        e isa ErrorException ? println(" could not determine DataType size.") : rethrow(e)
+    # This are some types for which sizeof is known to return a meaninful value
+    if isconcretetype(eltype(c)) && <:(eltype(c),Union{AbstractFloat,Signed,Unsigned,Bool})
+        DD.print_block_separator(io, "file size", blockwidth, blockwidth)
+        println(io, "\n  file size: ", formatbytes(cubesize(c)))
     end
     DD.print_block_close(io, blockwidth)
     # And if you want the array data to print:

--- a/src/Cubes/Cubes.jl
+++ b/src/Cubes/Cubes.jl
@@ -510,7 +510,11 @@ function DD.show_after(io::IO, mime, c::YAXArray)
     blockwidth = get(io, :blockwidth, 0)
     DD.print_block_separator(io, "file size", blockwidth, blockwidth)
     println(io, " ")
-    println(io, "  file size: ", formatbytes(cubesize(c)))
+    try
+        println(io, "  file size: ", formatbytes(cubesize(c)))
+    catch e
+        e isa ErrorException ? println(" could not determine DataType size.") : rethrow(e)
+    end
     DD.print_block_close(io, blockwidth)
     # And if you want the array data to print:
     # ndims(c) > 0 && println(io)


### PR DESCRIPTION
This error is preventing users from creating YAXArrays of Strings} and Unions that contain Strings.

closes #410 