### PR TITLE
Fix collect of `ConcatDiskArray`

### DIFF
--- a/src/Cubes/Cubes.jl
+++ b/src/Cubes/Cubes.jl
@@ -169,7 +169,7 @@ function Base.propertynames(a::YAXArray, private::Bool=false)
     end
 end
 
-
+Base.Generator(f, A::YAXArray) = Base.Generator(f, parent(A))
 Base.ndims(a::YAXArray{<:Any,N}) where {N} = N
 Base.eltype(a::YAXArray{T}) where {T} = T
 function Base.permutedims(c::YAXArray, p) 

--- a/src/YAXTools.jl
+++ b/src/YAXTools.jl
@@ -14,7 +14,7 @@ struct Window
 end
 
 
-function PickAxisArray(parent, indmask, perm = nothing)
+function PickAxisArray(parent, indmask, perm=nothing)
     f = findall(isequal(true), indmask)
     f2 = findall(isequal(Colon()), indmask)
     f3 = findall(i -> isa(i, Tuple{Int,Int}), indmask)
@@ -80,3 +80,5 @@ function Base.eltype(p::PickAxisArray{T}) where {T}
 end
 Base.getindex(p::PickAxisArray, i::CartesianIndex) = p[i.I...]
 end
+
+Base.Generator(f, A::YAXArray) = Base.Generator(f, parent(A))

--- a/src/YAXTools.jl
+++ b/src/YAXTools.jl
@@ -80,5 +80,3 @@ function Base.eltype(p::PickAxisArray{T}) where {T}
 end
 Base.getindex(p::PickAxisArray, i::CartesianIndex) = p[i.I...]
 end
-
-Base.Generator(f, A::YAXArray) = Base.Generator(f, parent(A))


### PR DESCRIPTION
This PR aims to fix the display order of `ConcatDiskArray`.
Unfortunately, this is going to clash with the DimensionalData.jl Generator behavior, which in a lot of cases will return a DimArray because of the DimUnitRanges returned from axes.
See also https://github.com/meggart/DiskArrays.jl/issues/185  and https://github.com/rafaqz/DimensionalData.jl/issues/771

```julia
using DimensionalData
using YAXArrays
using Zarr
using GLMakie

lon_range = X(-180:180)
lat_range = Y(-90:90)
data = [exp(cosd(lon)) + 3 * (lat / 90) for lon in lon_range, lat in lat_range]
a = YAXArray((lon_range, lat_range), data)
ds_ram = Dataset(; properties=Dict(), a)
path = tempname()
savedataset(ds_ram; path=path)
ds_disk = open_dataset(path)
a_ram = cat(ds_ram.a[X=1:100], ds_ram.a[X=101:200], dims=:X)
a_disk = cat(ds_disk.a[X=1:100], ds_disk.a[X=101:200], dims=:X)

all(a_disk .== a_ram) # ok
heatmap(a_ram) # ok
heatmap(a_disk) # bug
heatmap(collect(a_disk)) # ok
```

![image](https://github.com/user-attachments/assets/81f043cb-d9c2-41a5-8cd9-8294ce8a222f)
