### PR TITLE
Fix rebuild

### DIFF
--- a/src/Cubes/Cubes.jl
+++ b/src/Cubes/Cubes.jl
@@ -200,7 +200,7 @@ function DD.rebuild(A::YAXArray, data::AbstractArray, dims::Tuple, refdims::Tupl
     #end
     YAXArray(dims, data, metadata; cleaner=A.cleaner)#, chunks=GridChunks(chunks))
 end
-function DD.rebuild(A::YAXArray; data=parent(A), dims=dims(A), metadata=DD.metadata(A), kw...)
+function DD.rebuild(A::YAXArray; data=parent(A), dims=DD.dims(A), metadata=DD.metadata(A), kw...)
     YAXArray(dims, data, metadata; cleaner=A.cleaner)
 end
 


### PR DESCRIPTION
```julia
rebuild(oldarray; data=newdata)
```

was throwing with

```julia
ERROR: UndefVarError: `dims` not defined
```

but 

```julia
rebuild(oldarray; data=newdata, dims=dims(oldarray))
```

seemed to work so I think this quick fix might help? (Not sure!)

Side question: Are there enough tests for `rebuild`?