### PR TITLE
Hint to data loading in show of a data cube

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,7 +23,7 @@ jobs:
           - x64
     steps:
       - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -44,6 +44,7 @@ jobs:
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN}}
           file: lcov.info
       - uses: coverallsapp/github-action@master
         with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.9'
+          - 'lts'
           - '1'
         os:
           - ubuntu-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -46,7 +46,3 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN}}
           file: lcov.info
-      - uses: coverallsapp/github-action@master
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: ./lcov.info

--- a/README.md
+++ b/README.md
@@ -18,9 +18,6 @@
 [ci-img]: https://github.com/JuliaDataCubes/YAXArrays.jl/workflows/CI/badge.svg
 [ci-url]: https://github.com/JuliaDataCubes/YAXArrays.jl/actions?query=workflow%3ACI
 
-[coveralls-img]: https://coveralls.io/repos/github/JuliaDataCubes/YAXArrays.jl/badge.svg?branch=master
-[coveralls-url]: https://coveralls.io/github/JuliaDataCubes/YAXArrays.jl?branch=master
-
 [zenodo-url]: https://doi.org/10.5281/zenodo.7505394
 [zenodo-img]: https://zenodo.org/badge/DOI/10.5281/zenodo.7505394.svg
 

--- a/src/Cubes/Cubes.jl
+++ b/src/Cubes/Cubes.jl
@@ -506,16 +506,19 @@ getCubeDes(::DD.Dimension) = "Cube axis"
 getCubeDes(::YAXArray) = "YAXArray"
 getCubeDes(::Type{T}) where {T} = string(T)
 
+loadingstatus(x) = "loaded in memory"
+loadingstatus(x::DiskArrays.AbstractDiskArray) = "loaded lazily"
+
 function DD.show_after(io::IO, mime, c::YAXArray)
     blockwidth = get(io, :blockwidth, 0)
+    DD.print_block_separator(io, loadingstatus(parent(c)), blockwidth, blockwidth)
+
     # ? sizeof : Check if the element type is a bitstype or a union of bitstypes
     if (isconcretetype(eltype(c)) && isbitstype(eltype(c))) ||
         (eltype(c) isa Union && all(isbitstype, Base.uniontypes(eltype(c))))
 
-        DD.print_block_separator(io, "file size", blockwidth, blockwidth)
-        println(io, "\n  file size: ", formatbytes(cubesize(c)))
+        println(io, "\n  data size: ", formatbytes(cubesize(c)))
     else # fallback
-        DD.print_block_separator(io, "memory size", blockwidth, blockwidth)
         println(io, "\n  summarysize: ", formatbytes(Base.summarysize(parent(c))))
     end
     DD.print_block_close(io, blockwidth)

--- a/src/Cubes/Cubes.jl
+++ b/src/Cubes/Cubes.jl
@@ -228,6 +228,10 @@ Cubes.caxes(x::DD.Dimension) = (x,)
 Given any array implementing the YAXArray interface it returns an in-memory [`YAXArray`](@ref) from it.
 """
 function readcubedata(x)
+    csize = cubesize(x)
+    if csize > YAXDefaults.max_cache[]
+        @warn "Loading a Cube of size $(formatbytes(csize))."
+    end
     YAXArray(caxes(x), getindex_all(x), getattributes(x))
 end
 

--- a/src/DatasetAPI/Datasets.jl
+++ b/src/DatasetAPI/Datasets.jl
@@ -1,6 +1,6 @@
 module Datasets
 #import ..Cubes.Axes: axsym, axname, CubeAxis, findAxis, CategoricalAxis, RangeAxis, caxes
-import ..Cubes: Cubes, YAXArray, concatenatecubes, CleanMe, subsetcube, copy_diskarray, setchunks, caxes, readcubedata
+import ..Cubes: Cubes, YAXArray, concatenatecubes, CleanMe, subsetcube, copy_diskarray, setchunks, caxes, readcubedata, cubesize, formatbytes
 using ...YAXArrays: YAXArrays, YAXDefaults, findAxis
 using DataStructures: OrderedDict, counter
 using Dates: Day, Hour, Minute, Second, Month, Year, Date, DateTime, TimeType, AbstractDateTime
@@ -180,6 +180,10 @@ function Base.getproperty(x::Dataset, k::Symbol)
 end
 
 function readcubedata(ds::Dataset)
+    dssize = sum(cubesize.(values(ds.cubes)))
+    if dssize > YAXDefaults.max_cache[]
+        @warn "Loading data of size $(formatbytes(dssize))"
+    end
     inmemcubes = OrderedDict(key=> readcubedata(val) for (key, val) in pairs(ds.cubes))
     Dataset(inmemcubes, ds.axes, ds.properties)
 end

--- a/src/DatasetAPI/Datasets.jl
+++ b/src/DatasetAPI/Datasets.jl
@@ -1,6 +1,6 @@
 module Datasets
 #import ..Cubes.Axes: axsym, axname, CubeAxis, findAxis, CategoricalAxis, RangeAxis, caxes
-import ..Cubes: Cubes, YAXArray, concatenatecubes, CleanMe, subsetcube, copy_diskarray, setchunks, caxes
+import ..Cubes: Cubes, YAXArray, concatenatecubes, CleanMe, subsetcube, copy_diskarray, setchunks, caxes, readcubedata
 using ...YAXArrays: YAXArrays, YAXDefaults, findAxis
 using DataStructures: OrderedDict, counter
 using Dates: Day, Hour, Minute, Second, Month, Year, Date, DateTime, TimeType, AbstractDateTime
@@ -178,6 +178,12 @@ function Base.getproperty(x::Dataset, k::Symbol)
         x[k]
     end
 end
+
+function readcubedata(ds::Dataset)
+    inmemcubes = OrderedDict(key=> readcubedata(val) for (key, val) in pairs(ds.cubes))
+    Dataset(inmemcubes, ds.axes, ds.properties)
+end
+
 Base.getindex(x::Dataset, i::Symbol) =
 haskey(x.cubes, i) ? x.cubes[i] :
 haskey(x.axes, i) ? x.axes[i] : throw(ArgumentError("$i not found in Dataset"))

--- a/test/Datasets/datasets.jl
+++ b/test/Datasets/datasets.jl
@@ -319,6 +319,11 @@ end
     @test ds.b.data == y
     @test ds.b.chunks == b.chunks
 
+    @test ds.b.data isa AbstractDiskArray
+    inmemds = readcubedata(ds)
+    @test !isa(inmemds.b.data, AbstractDiskArray)
+
+
     ds2 = Dataset(c=c)
     savedataset(ds2, path=f, backend=:zarr, append=true)
     ds = open_dataset(f, driver=:zarr)


### PR DESCRIPTION
This would fix the first part of #447 and indicates the loading status of the data of a YAXArray. 
With this PR:

```julia
julia> c
╭────────────────────────────╮
│ 2200×201 YAXArray{Int16,2} │
├────────────────────────────┴───────────────────────────────────────────────────────────────────────────── dims ┐
  ↓ lon Sampled{Float64} -179.99955555555556:0.00088888888888:-178.04488888890845 ForwardOrdered Regular Points,
  → lat Sampled{Float64} 79.11155555556444:-0.00088888888888:78.93377777778844 ReverseOrdered Regular Points
├────────────────────────────────────────────────────────────────────────────────────────────────────── metadata ┤
  Dict{String, Any} with 8 entries:
  "units"               => "Mg/ha"
  "name"                => "agb"
  "long_name"           => "Above-ground biomass"
  "grid_mapping"        => "crs"
  "valid_min"           => 0.0
  "ancillary_variables" => "agb_se"
  "_FillValue"          => -32768
  "valid_max"           => 10000.0
├────────────────────────────────────────────────────────────────────────────────────────────── loaded in memory ┤
  data size: 863.67 KB
└────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
```
