### PR TITLE
allow uppercase date units in cf conventions

### DIFF
--- a/src/DatasetAPI/Datasets.jl
+++ b/src/DatasetAPI/Datasets.jl
@@ -279,7 +279,7 @@ function toaxis(dimname, g, offs, len)
     end
     ar = get_var_handle(g, dimname)
     aratts = get_var_attrs(g, dimname)
-    if match(r"^(days)|(hours)|(seconds)|(months) since",get(aratts,"units","")) !== nothing
+    if match(r"^(days)|(hours)|(seconds)|(months) since",lowercase(get(aratts,"units",""))) !== nothing
         tsteps = try
             timedecode(ar[:], aratts["units"], lowercase(get(aratts, "calendar", "standard")))
         catch


### PR DESCRIPTION
This fixes an issue that time units are not parsed correctly when unit is specified in upper case e.g. `"Days since 1990-01-01"` instead of `"days since 1990-01-01"`.