### PR TITLE
replace caxes by dims

### DIFF
--- a/src/Cubes/Cubes.jl
+++ b/src/Cubes/Cubes.jl
@@ -204,16 +204,16 @@ function DD.rebuild(A::YAXArray; data=parent(A), dims=DD.dims(A), metadata=DD.me
     YAXArray(dims, data, metadata; cleaner=A.cleaner)
 end
 
-# function caxes(x)
-#     #@show x
-#     #@show typeof(x)
-#     dims = map(enumerate(dimnames(x))) do a
-#         index, symbol = a
-#         values = YAXArrayBase.dimvals(x, index)
-#         DD.Dim{symbol}(values)
-#     end
-#     (dims... ,)
-# end
+function caxes(x)
+     #@show x
+     #@show typeof(x)
+     dims = map(enumerate(dimnames(x))) do a
+         index, symbol = a
+         values = YAXArrayBase.dimvals(x, index)
+         DD.Dim{symbol}(values)
+     end
+     (dims... ,)
+end
 
 caxes(x::DD.AbstractDimArray) = collect(DD.dims(x))
 

--- a/src/Cubes/Cubes.jl
+++ b/src/Cubes/Cubes.jl
@@ -215,7 +215,7 @@ end
 #     (dims... ,)
 # end
 
-caxes(x) = collect(DD.dims(x))
+caxes(x::DD.AbstractDimArray) = collect(DD.dims(x))
 
 caxes(c::YAXArray) = getfield(c, :axes)
 """

--- a/src/Cubes/Cubes.jl
+++ b/src/Cubes/Cubes.jl
@@ -215,7 +215,7 @@ end
 #     (dims... ,)
 # end
 
-caxes(x) = DD.dims(x)
+caxes(x) = collect(DD.dims(x))
 
 caxes(c::YAXArray) = getfield(c, :axes)
 """

--- a/src/Cubes/Cubes.jl
+++ b/src/Cubes/Cubes.jl
@@ -204,16 +204,19 @@ function DD.rebuild(A::YAXArray; data=parent(A), dims=DD.dims(A), metadata=DD.me
     YAXArray(dims, data, metadata; cleaner=A.cleaner)
 end
 
-function caxes(x)
-    #@show x
-    #@show typeof(x)
-    dims = map(enumerate(dimnames(x))) do a
-        index, symbol = a
-        values = YAXArrayBase.dimvals(x, index)
-        DD.Dim{symbol}(values)
-    end
-    (dims... ,)
-end
+# function caxes(x)
+#     #@show x
+#     #@show typeof(x)
+#     dims = map(enumerate(dimnames(x))) do a
+#         index, symbol = a
+#         values = YAXArrayBase.dimvals(x, index)
+#         DD.Dim{symbol}(values)
+#     end
+#     (dims... ,)
+# end
+
+caxes(x) = DD.dims(x)
+
 caxes(c::YAXArray) = getfield(c, :axes)
 """
     caxes


### PR DESCRIPTION
- [ ] remove `caxes(x)` and replace by `dims(x)`
- [ ] arrays vs tuple ?, `dims` outputs a tuple and `caxes` an array
- [ ] fix tests