### PR TITLE
Fix open dataset with length 1 dim

### DIFF
--- a/src/DatasetAPI/Datasets.jl
+++ b/src/DatasetAPI/Datasets.jl
@@ -318,6 +318,7 @@ function testrange(x)
 end
 
 function testrange(x::AbstractArray{<:Integer})
+    length(x) == 1 && return x
     steps = diff(x)
     if all(isequal(steps[1]), steps) && !iszero(steps[1])
         return range(first(x), step = steps[1], length = length(x))

--- a/test/Datasets/datasets.jl
+++ b/test/Datasets/datasets.jl
@@ -419,6 +419,15 @@ end
     @test :b in keys(ds3.cubes)
     @test !in(:c,keys(ds3.cubes))
 
+    # arrays with a dimension of length 1
+    a4 = YAXArray(ones(5, 1))
+    ds4 = Dataset(layer=a4)
+    path = tempname() * ".zarr"
+    savedataset(ds4; path=path)
+    ds5 = open_dataset(path)
+    @test length(ds4.Dim_2) == length(ds5.Dim_2) == 1
+    @test ds4.Dim_2 == ds5.Dim_2
+    rm(path, recursive=true, force=true)
 end
 
 @testset "Saving, OutDims" begin


### PR DESCRIPTION
This PR aims to Fix opening a `Dataset` with an `YAXArray` having a integer dimension of length 1. Thanks, @meggart, for the hint!

```julia
using YAXArrays
using Zarr
a = YAXArray(ones(5, 1))
ds = Dataset(layer=a)
path = tempname() * ".zarr"
savedataset(ds; path=path)
ds2 = open_dataset(path)
```

results in error:

```
ERROR: BoundsError: attempt to access 0-element Vector{Int64} at index [1]
Stacktrace:
  [1] throw_boundserror(A::Vector{Int64}, I::Tuple{Int64})
    @ Base ./essentials.jl:14
  [2] getindex
    @ ./essentials.jl:916 [inlined]
  [3] testrange(x::Vector{Int64})
    @ YAXArrays.Datasets ~/.julia/packages/YAXArrays/x5iTf/src/DatasetAPI/Datasets.jl:321
  [4] toaxis(dimname::String, g::ZarrExt.ZarrDataset, offs::Int64, len::Int64)
    @ YAXArrays.Datasets ~/.julia/packages/YAXArrays/x5iTf/src/DatasetAPI/Datasets.jl:294
  [5] (::YAXArrays.Datasets.var"#44#46"{ZarrExt.ZarrDataset})(d::Tuple{String, Int64, Int64})
    @ YAXArrays.Datasets ./none:0
  [6] iterate
    @ ./generator.jl:48 [inlined]
  [7] grow_to!(dest::Dict{String, @NamedTuple{…}}, itr::Base.Generator{Set{…}, YAXArrays.Datasets.var"#44#46"{…}}, st::Int64)
    @ Base ./abstractdict.jl:606
  [8] grow_to!(dest::Dict{Any, Any}, itr::Base.Generator{Set{Tuple{…}}, YAXArrays.Datasets.var"#44#46"{ZarrExt.ZarrDataset}})
    @ Base ./abstractdict.jl:602
  [9] dict_with_eltype
    @ ./abstractdict.jl:641 [inlined]
 [10] Dict
    @ ./dict.jl:117 [inlined]
 [11] collectdims(g::ZarrExt.ZarrDataset)
    @ YAXArrays.Datasets ~/.julia/packages/YAXArrays/x5iTf/src/DatasetAPI/Datasets.jl:269
 [12] (::YAXArrays.Datasets.var"#67#75"{Tuple{}})(g::ZarrExt.ZarrDataset)
    @ YAXArrays.Datasets ~/.julia/packages/YAXArrays/x5iTf/src/DatasetAPI/Datasets.jl:435
 [13] open_dataset_handle(f::YAXArrays.Datasets.var"#67#75"{Tuple{}}, ds::ZarrExt.ZarrDataset)
    @ YAXArrayBase ~/.julia/packages/YAXArrayBase/M48vP/src/datasets/datasetinterface.jl:23
 [14] open_dataset(g::String; skip_keys::Tuple{}, driver::Symbol)
    @ YAXArrays.Datasets ~/.julia/packages/YAXArrays/x5iTf/src/DatasetAPI/Datasets.jl:433
 [15] open_dataset(g::String)
    @ YAXArrays.Datasets ~/.julia/packages/YAXArrays/x5iTf/src/DatasetAPI/Datasets.jl:430
 [16] top-level scope
    @ REPL[7]:1
Some type information was truncated. Use `show(err)` to see complete types.
```