### PR TITLE
Remove windows and macos from the test matrix

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,8 +17,6 @@ jobs:
           - '1'
         os:
           - ubuntu-latest
-          - macOS-latest
-          - windows-latest
         arch:
           - x64
     steps:


### PR DESCRIPTION
This removes the tests on windows and macOS from  CI. This would then close #535 . Let's see whether the coverage would drop. 

Maybe we can find a way to at least test on all OSes for the releases because there might be slight differences that would be good to catch. 

