### PR TITLE
Fix datetime conversion bug

### DIFF
--- a/src/DatasetAPI/Datasets.jl
+++ b/src/DatasetAPI/Datasets.jl
@@ -289,7 +289,7 @@ function toaxis(dimname, g, offs, len)
     if match(r"^(days)|(hours)|(seconds)|(months) since",lowercase(get(aratts,"units",""))) !== nothing
         tsteps = try
             dec = timedecode(ar[:], aratts["units"], lowercase(get(aratts, "calendar", "standard")), prefer_datetime=false)
-            prefer_datetime && round_datetime.(dec)
+            round_datetime.(dec)
         catch
             ar[:]
         end


### PR DESCRIPTION
This fixes a bug similar to the one described by @felixcremer in https://github.com/rafaqz/Rasters.jl/issues/1000 by rounding to the closest millisecond before converting time stamps to DateTime. 