### PR TITLE
support saving Strings of variable length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,6 @@
 
 ## Unreleased
 
+- Support variable-length element types (e.g. `String`) in `savecube`/`savedataset` by no
+  longer requiring a definite `sizeof` for the element type
 - DiskArrayEngine integration

--- a/src/Cubes/Cubes.jl
+++ b/src/Cubes/Cubes.jl
@@ -517,8 +517,19 @@ function formatbytes(x)
     end
     return string(round(x, digits=2), " ", exts[i])
 end
-cubesize(c::YAXArray{T}) where {T} = (sizeof(T)) * prod(map(length, caxes(c)))
-cubesize(::YAXArray{T,0}) where {T} = sizeof(T)
+
+"""
+    _elsize(T)
+
+Like `sizeof`, but returns a fallback estimate for element types without a
+definite size (e.g. `String` and other non-`isbitstype` types, which are stored
+by reference). Lets buffer- and size-computations work for variable-length
+element types instead of throwing `"Type ... does not have a definite size"`.
+"""
+_elsize(::Type{T}) where {T} = isconcretetype(T) && isbitstype(T) ? sizeof(T) : sizeof(Ptr{Cvoid})
+
+cubesize(c::YAXArray{T}) where {T} = _elsize(T) * prod(map(length, caxes(c)))
+cubesize(::YAXArray{T,0}) where {T} = _elsize(T)
 
 getCubeDes(::DD.Dimension) = "Cube axis"
 getCubeDes(::YAXArray) = "YAXArray"

--- a/src/Cubes/Rechunker.jl
+++ b/src/Cubes/Rechunker.jl
@@ -52,7 +52,7 @@ function outalign(buf,sout)
 end
 
 function get_copy_buffer_size(incube, outcube;writefac=4.0, maxbuf = YAXDefaults.max_cache[], align_output=true)
-    maxbuf = round(Int,maxbuf/sizeof(eltype(incube)))
+    maxbuf = round(Int,maxbuf/_elsize(eltype(incube)))
     nd = ndims(incube)
     if nd == 1
         return (min(maxbuf,length(incube)),)

--- a/src/DAT/DAT.jl
+++ b/src/DAT/DAT.jl
@@ -758,7 +758,7 @@ end
 function getbackend(oc, ispar, max_cache)
     elementtype = Union{oc.outtype,Missing}
     outsize =
-        sizeof(elementtype) * (length(oc.allAxes) > 0 ? prod(map(length, oc.allAxes)) : 1)
+        Cubes._elsize(elementtype) * (length(oc.allAxes) > 0 ? prod(map(length, oc.allAxes)) : 1)
     rt = oc.desc.backend
     ispath =  get(oc.desc.backendargs, :path, nothing)
 
@@ -915,8 +915,7 @@ function analyzeAxes(dc::DATConfig{NIN,NOUT}) where {NIN,NOUT}
     return dc
 end
 
-mysizeof(x) = sizeof(x)
-mysizeof(x::Type{String}) = 1
+mysizeof(x) = Cubes._elsize(x)
 
 """
 Function that compares two cache miss specifiers by their importance
@@ -944,7 +943,7 @@ function getCacheSizes(dc::DATConfig, loopchunksizes)
     outblocksizes = map(
         C ->
             length(C.axesSmall) > 0 ?
-            sizeof(C.outtype) * prod(map(Int ∘ length, C.axesSmall)) : 1,
+            Cubes._elsize(C.outtype) * prod(map(Int ∘ length, C.axesSmall)) : 1,
         dc.outcubes,
     )
     outblocksize = length(outblocksizes) > 0 ? sum(outblocksizes) : 1

--- a/test/Datasets/datasets.jl
+++ b/test/Datasets/datasets.jl
@@ -605,3 +605,22 @@ end
     @test ds.layer.data[:,:,1:2] == array1
     @test ds.layer.data[:,:,3:4] == array2
 end
+
+@testset "Saving variable-length strings" begin
+    using NetCDF, Zarr, YAXArrays
+    @test YAXArrays.Cubes._elsize(String) == sizeof(Ptr{Cvoid})
+    @test YAXArrays.Cubes._elsize(Float64) == 8
+
+    data = ["a", "bb", "ccc", "dddd"]
+    a = YAXArray((Dim{:Ax}(1:4),), data)
+
+    f = string(tempname(), ".zarr")
+    savecube(a, f, backend=:zarr)
+    @test ispath(f)
+    @test collect(Cube(f).data) == data
+
+    f = string(tempname(), ".nc")
+    savecube(a, f, backend=:netcdf)
+    @test ispath(f)
+    @test collect(Cube(f).data) == data
+end


### PR DESCRIPTION
claude did the heavy lifting here.  let me know what you think.  works in practice for me and very useful.  

## Summary
  
  Saving a cube whose element type has no definite size (e.g. `String`) currently
  crashes:

  ERROR: Type String does not have a definite size.
  Stacktrace:
   [1] sizeof(x::Type) @ Base ./essentials.jl:783
   [2] get_copy_buffer_size(...) @ YAXArrays.Cubes .../Cubes/Rechunker.jl:55
   [3] copy_diskarray(...) @ YAXArrays.Cubes .../Cubes/Rechunker.jl:108
   [4] copydataset!(...) @ YAXArrays.Datasets .../DatasetAPI/Datasets.jl:635
   ...
   [8] savecube(...) @ YAXArrays.Datasets .../DatasetAPI/Datasets.jl:813

  The backend variable is created fine — the only blocker is the buffer-size
  heuristic in the rechunker, which calls `sizeof(eltype(incube))` directly.
  `sizeof` throws for any non-`isbitstype` element type, since such values are
  stored by reference rather than inline.

  ## Changes
  
  - Add `Cubes._elsize(T)`: like `sizeof`, but returns a pointer-sized fallback
    (`sizeof(Ptr{Cvoid})`) for element types without a definite size. The copy
    buffer holds element *references*, so a pointer-sized footprint is the right
    estimate for cache budgeting, and it's safely bounded by the existing
    `min(maxbuf, length)` / `maxbuf > prod(insize)` guards in
    `get_copy_buffer_size`.
  - Use `_elsize` in `get_copy_buffer_size` (the reported crash) and in
    `cubesize`, which had the same latent `sizeof(T)` issue.
  - Unify the pre-existing ad-hoc workarounds in `DAT.jl` to call `_elsize`:
    - `mysizeof` (previously a special-cased `mysizeof(::Type{String}) = 1`)
    - `getbackend`, where `elementtype = Union{oc.outtype,Missing}` would also
      throw for a string output type
    - `getCacheSizes` (`sizeof(C.outtype)`)

  ## Tests
  
  Adds a `"Saving variable-length strings"` testset that round-trips a
  `YAXArray{String}` through both the Zarr and NetCDF backends, plus unit checks
  on `_elsize` itself. Verified passing locally.

  ## Notes

  - The `show_after` display path is intentionally left unchanged — it already
    branches on `isbitstype`/`Union` and uses `Base.summarysize` for
    variable-length element types, which is more accurate for display than an
    estimate.
